### PR TITLE
Only process Esi tags replacements in Esi tags.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var URL =  require('url');
 //
 module.exports = function( req, res, next ){
 
-	// Set debug level in module	
+	// Set debug level in module
 	ESI.debug = module.exports.debug;
 
 	// Define the VARS which will be passed
@@ -64,7 +64,7 @@ module.exports = function( req, res, next ){
 			esi.then( null, function(e){
 
 				// on error
-				// Write nothing out 
+				// Write nothing out
 				return '';
 
 			}).then( function( r ){
@@ -109,8 +109,7 @@ module.exports = function( req, res, next ){
 			res.removeHeader('content-length');
 
 		// Does this have an ESI fragment
-
-		var esi = ESI( chunk, encoding, VARS );
+		var esi = ESI( chunk, encoding, VARS, false );
 
 
 		// Push the request into a queue
@@ -129,7 +128,7 @@ module.exports = function( req, res, next ){
 	res.end = function( data, encoding ){
 
 		ended = true;
-		
+
 		// resuse overriden res.write
 		res.write( data, encoding );
 

--- a/specs/e2e.js
+++ b/specs/e2e.js
@@ -87,6 +87,22 @@ describe("ESI via webserver", function(){
 	});
 
 
+
+	it("should replace only in esi tags", function(done){
+
+		// Assign custom variables
+		ESIConnect.vars.customOk = 'ok';
+		ESIConnect.vars.customGood = 'good';
+
+		var snipet = 'foo<esi:vars>$(customOk)</esi:vars>bar<esi:vars>$(customGood)</esi:vars>';
+
+		request(testCDN)
+			.get('/'+snipet)
+			.expect(200, 'foookbargood' )
+			.end(done);
+	});
+
+
 	describe("should assign default HTTP VARS", function(){
 
 		[


### PR DESCRIPTION
When Esi middleware parse body string, process Esi tags replacements only
if splitted body matches with Esi regex or if current splitted body is
related to previous Esi tag.
- [x] `npm test`
